### PR TITLE
fix extra quotes on Oban.AppsignalTelemetryLogger transaction incidents

### DIFF
--- a/lib/goodies/oban/v1/appsignal_telemetry_logger.ex
+++ b/lib/goodies/oban/v1/appsignal_telemetry_logger.ex
@@ -50,11 +50,15 @@ defmodule Goodies.Oban.V1.AppsignalTelemetryLogger do
   defp normalize_error(error_metadata)
 
   defp normalize_error(%{kind: :error, error: error, stack: stack, worker: worker}) do
-    {"#{worker}Error", inspect(error, limit: :infinity), stack}
+    {"#{worker}Error", stringify(error), stack}
   end
 
   defp normalize_error(%{kind: :exception, error: error, stack: stack}) do
     {reason, message} = Error.metadata(error)
-    {inspect(reason), inspect(message, limit: :infinity), stack}
+    {stringify(reason), stringify(message), stack}
+  end
+
+  defp stringify(value) do
+    if is_binary(value), do: value, else: inspect(value, limit: :infinity)
   end
 end

--- a/lib/goodies/oban/v2/appsignal_telemetry_logger.ex
+++ b/lib/goodies/oban/v2/appsignal_telemetry_logger.ex
@@ -50,6 +50,10 @@ defmodule Goodies.Oban.V2.AppsignalTelemetryLogger do
 
   defp normalize_error(%{error: error, stacktrace: stack}) do
     {reason, message} = Error.metadata(error)
-    {inspect(reason), inspect(message, limit: :infinity), stack}
+    {stringify(reason), stringify(message), stack}
+  end
+
+  defp stringify(value) do
+    if is_binary(value), do: value, else: inspect(value, limit: :infinity)
   end
 end

--- a/test/goodies/oban/v1/appsignal_telemetry_logger_test.exs
+++ b/test/goodies/oban/v1/appsignal_telemetry_logger_test.exs
@@ -47,7 +47,7 @@ defmodule Goodies.Oban.V1.AppsignalTelemetryLoggerTest do
                  :ok
 
         assert called(Transaction.start(:_, :_))
-        assert called(Transaction.set_error(:_, "\"RuntimeError\"", "\"runtime error\"", []))
+        assert called(Transaction.set_error(:_, "RuntimeError", "runtime error", []))
         assert called(Transaction.complete(:_))
       end
     end

--- a/test/goodies/oban/v2/appsignal_telemetry_logger_test.exs
+++ b/test/goodies/oban/v2/appsignal_telemetry_logger_test.exs
@@ -65,7 +65,7 @@ defmodule Goodies.Oban.V2.AppsignalTelemetryLoggerTest do
                  :ok
 
         assert called(Transaction.start(:_, :_))
-        assert called(Transaction.set_error(:_, "\"RuntimeError\"", "\"runtime error\"", []))
+        assert called(Transaction.set_error(:_, "RuntimeError", "runtime error", []))
         assert called(Transaction.complete(:_))
       end
     end
@@ -103,8 +103,8 @@ defmodule Goodies.Oban.V2.AppsignalTelemetryLoggerTest do
         assert called(
                  Transaction.set_error(
                    :_,
-                   "\"Goodies.Oban.V2.AppsignalTelemetryLoggerTest.Oban.PerformError\"",
-                   "\"MyApp.TupleFailureWorker failed with {:error, \\\"some error\\\"}\"",
+                   "Goodies.Oban.V2.AppsignalTelemetryLoggerTest.Oban.PerformError",
+                   "MyApp.TupleFailureWorker failed with {:error, \"some error\"}",
                    []
                  )
                )


### PR DESCRIPTION
remove extra quotes of Appsignal incidents like [this](https://appsignal.com/bcredi/sites/5cb9da845ac13f0787efa635/exceptions/incidents/352/samples/5f7df24dcbf15e0d1baeae70).