### PR TITLE
[ETEAM-25] fix Conduit.Plug.RequestId behaviour when there's no correlation_id and request_id

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+**Why is this change necessary?**
+
+- Users were being redirected to the home page after login, which is less
+  useful than redirecting to the page they had originally requested before
+  being redirected to the login form.
+
+**How does it address the issue?**
+
+- Introduce a red/black tree to increase search speed
+- Remove *troublesome lib X*, which was causing *specific description of issue introduced by lib*;
+
+**What side effects does this change have?**
+
+- Requires database migration 
+- Requires mix task X executed;
+
+**Task card (link)**
+
+- [Card Title](https://bcredi.atlassian.net/browse/MC-01)

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,13 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 1
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 1
+# Label to use when marking an issue as stale
+staleLabel: timeout
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false

--- a/README.md
+++ b/README.md
@@ -1,21 +1,16 @@
 # Goodies
 
-**TODO: Add description**
+Shared helper modules for Bcredi Platform.
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `goodies` to your list of dependencies in `mix.exs`:
+Add `goodies` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:goodies, "~> 0.1.0"}
+    {:goodies, github: "bcredi/goodies"}
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/goodies](https://hexdocs.pm/goodies).
 

--- a/lib/goodies/conduit/plug/request_id.ex
+++ b/lib/goodies/conduit/plug/request_id.ex
@@ -35,14 +35,10 @@ defmodule Goodies.Conduit.Plug.RequestId do
   and always assigns it to the logger metadata.
   """
   def call(message, next, _opts) do
-    request_id = Logger.metadata()[:request_id]
-
-    message =
-      if is_nil(request_id),
-        do: message,
-        else: put_new_correlation_id(message, request_id)
+    correlation_id = Logger.metadata()[:request_id] || UUID.uuid4()
 
     message
+    |> put_new_correlation_id(correlation_id)
     |> put_logger_metadata()
     |> next.()
   end

--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,8 @@ defmodule Goodies.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:conduit, "~> 0.12"},
-      {:tesla, "~> 1.3"},
+      {:conduit, "~> 0.12", optional: true},
+      {:tesla, "~> 1.3", optional: true},
       {:appsignal, "~> 1.0"},
       {:credo, "~> 1.4.0", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0", only: [:dev], runtime: false},


### PR DESCRIPTION
**Why is this change necessary?**

- To support creating correlation_id for Conduit/RabbitMQ messages when there's no correlation_id/request_id already, e.g., in an Oban worker.

**How does it address the issue?**

- Create correlation_id on `Goodies.Conduit.Plug.RequestId`;
- Add missing github configuration;
- Improve README.

**What side effects does this change have?**

- Upgrade `goodies` dependency on all services that use Conduit.

**Task card (link)**

- [ETEAM-25](https://bcredi.atlassian.net/browse/ETEAM-25)