### PR TITLE
[ETEAM-25] check optional dependencies presence before loading modules

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -2,9 +2,9 @@ name: Elixir CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -1,0 +1,39 @@
+name: Elixir CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Elixir
+        uses: actions/setup-elixir@v1
+        with:
+          elixir-version: "1.11.4" # Define the elixir version [required]
+          otp-version: "23.2" # Define the OTP version [required]
+          experimental-otp: true # Issue https://github.com/actions/setup-elixir/issues/49
+      - name: Restore dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
+      - name: Run tests
+        run: mix coveralls
+      - name: Run credo
+        run: mix credo --strict
+      - name: Run format
+        run: mix format --check-formatted

--- a/lib/goodies/conduit/plug/dead_letter.ex
+++ b/lib/goodies/conduit/plug/dead_letter.ex
@@ -1,61 +1,63 @@
-defmodule Goodies.Conduit.Plug.DeadLetter do
-  use Conduit.Plug.Builder
+if Code.ensure_loaded?(Conduit) do
+  defmodule Goodies.Conduit.Plug.DeadLetter do
+    use Conduit.Plug.Builder
 
-  @moduledoc """
-  Publishes messages that were nacked or raised an exception to a
-  dead letter destination and ack them to be removed from the regular queue.
+    @moduledoc """
+    Publishes messages that were nacked or raised an exception to a
+    dead letter destination and ack them to be removed from the regular queue.
 
-  Based on original `Conduit.Plug.DeadLetter`.
+    Based on original `Conduit.Plug.DeadLetter`.
 
-  The following options are required:
+    The following options are required:
 
-    * `broker` - The broker to publish the message with.
-    * `publish_to` - The place to publish the message.
+      * `broker` - The broker to publish the message with.
+      * `publish_to` - The place to publish the message.
 
-  In order for this to work, you must also define an outgoing publish with the same
-  name as the `publish_to` option in your broker.
+    In order for this to work, you must also define an outgoing publish with the same
+    name as the `publish_to` option in your broker.
 
-      publish :error, to: "my_app.error"
+        publish :error, to: "my_app.error"
 
-  ## Examples
+    ## Examples
 
-      plug Goodies.Conduit.Plug.DeadLetter, broker: MyApp.Broker, publish_to: :error
+        plug Goodies.Conduit.Plug.DeadLetter, broker: MyApp.Broker, publish_to: :error
 
-  """
+    """
 
-  def init(opts) do
-    # Fail if opts are missing
-    _ = Keyword.fetch!(opts, :publish_to)
-    _ = Keyword.fetch!(opts, :broker)
+    def init(opts) do
+      # Fail if opts are missing
+      _ = Keyword.fetch!(opts, :publish_to)
+      _ = Keyword.fetch!(opts, :broker)
 
-    opts
-  end
-
-  @doc """
-  Publishes messages that were nacked or raised an exception to a
-  dead letter destination.
-  """
-  def call(message, next, opts) do
-    message = next.(message)
-
-    case message.status do
-      :nack -> publish_dead_letter(message, opts)
-      :ack -> message
+      opts
     end
-  rescue
-    error ->
-      message
-      |> put_header("exception", Exception.format(:error, error))
-      |> publish_dead_letter(opts)
-  end
 
-  @spec publish_dead_letter(Conduit.Message.t(), Keyword.t()) :: Conduit.Message.t()
-  defp publish_dead_letter(message, opts) do
-    broker = Keyword.get(opts, :broker)
-    publish_to = Keyword.get(opts, :publish_to)
+    @doc """
+    Publishes messages that were nacked or raised an exception to a
+    dead letter destination.
+    """
+    def call(message, next, opts) do
+      message = next.(message)
 
-    broker.publish(message, publish_to, opts)
+      case message.status do
+        :nack -> publish_dead_letter(message, opts)
+        :ack -> message
+      end
+    rescue
+      error ->
+        message
+        |> put_header("exception", Exception.format(:error, error))
+        |> publish_dead_letter(opts)
+    end
 
-    ack(message)
+    @spec publish_dead_letter(Conduit.Message.t(), Keyword.t()) :: Conduit.Message.t()
+    defp publish_dead_letter(message, opts) do
+      broker = Keyword.get(opts, :broker)
+      publish_to = Keyword.get(opts, :publish_to)
+
+      broker.publish(message, publish_to, opts)
+
+      ack(message)
+    end
   end
 end

--- a/lib/goodies/conduit/plug/request_id.ex
+++ b/lib/goodies/conduit/plug/request_id.ex
@@ -1,50 +1,52 @@
-defmodule Goodies.Conduit.Plug.RequestId do
-  use Conduit.Plug.Builder
-  require Logger
+if Code.ensure_loaded?(Conduit) do
+  defmodule Goodies.Conduit.Plug.RequestId do
+    use Conduit.Plug.Builder
+    require Logger
 
-  @moduledoc """
-  Assigns the `Logger.metadata()[:request_id]` for the correlation ID of the message if one isn't present
-  and always assigns it to the logger metadata.
+    @moduledoc """
+    Assigns the `Logger.metadata()[:request_id]` for the correlation ID of the message if one isn't present
+    and always assigns it to the logger metadata.
 
-  ## Examples
+    ## Examples
 
-      iex> defmodule MyPipeline do
-      iex>   use Conduit.Plug.Builder
-      iex>   plug Goodies.Conduit.Plug.RequestId
-      iex> end
-      iex>
-      iex> Logger.metadata(request_id: "123")
-      iex> message = MyPipeline.run(%Conduit.Message{})
-      iex> message.correlation_id == Logger.metadata()[:request_id]
-      true
+        iex> defmodule MyPipeline do
+        iex>   use Conduit.Plug.Builder
+        iex>   plug Goodies.Conduit.Plug.RequestId
+        iex> end
+        iex>
+        iex> Logger.metadata(request_id: "123")
+        iex> message = MyPipeline.run(%Conduit.Message{})
+        iex> message.correlation_id == Logger.metadata()[:request_id]
+        true
 
-      iex> defmodule MyPipeline do
-      iex>   use Conduit.Plug.Builder
-      iex>   plug Goodies.Conduit.Plug.RequestId
-      iex> end
-      iex>
-      iex> Logger.metadata(request_id: "123")
-      iex> message = MyPipeline.run(%Conduit.Message{correlation_id: "123456"})
-      iex> Logger.metadata()[:request_id] == "123456" and message.correlation_id == "123456"
-      true
+        iex> defmodule MyPipeline do
+        iex>   use Conduit.Plug.Builder
+        iex>   plug Goodies.Conduit.Plug.RequestId
+        iex> end
+        iex>
+        iex> Logger.metadata(request_id: "123")
+        iex> message = MyPipeline.run(%Conduit.Message{correlation_id: "123456"})
+        iex> Logger.metadata()[:request_id] == "123456" and message.correlation_id == "123456"
+        true
 
-  """
+    """
 
-  @doc """
-  Assigns the `Logger.metadata()[:request_id]` for the correlation ID of the message if one isn't present
-  and always assigns it to the logger metadata.
-  """
-  def call(message, next, _opts) do
-    correlation_id = Logger.metadata()[:request_id] || UUID.uuid4()
+    @doc """
+    Assigns the `Logger.metadata()[:request_id]` for the correlation ID of the message if one isn't present
+    and always assigns it to the logger metadata.
+    """
+    def call(message, next, _opts) do
+      correlation_id = Logger.metadata()[:request_id] || UUID.uuid4()
 
-    message
-    |> put_new_correlation_id(correlation_id)
-    |> put_logger_metadata()
-    |> next.()
-  end
+      message
+      |> put_new_correlation_id(correlation_id)
+      |> put_logger_metadata()
+      |> next.()
+    end
 
-  defp put_logger_metadata(message) do
-    Logger.metadata(request_id: message.correlation_id)
-    message
+    defp put_logger_metadata(message) do
+      Logger.metadata(request_id: message.correlation_id)
+      message
+    end
   end
 end

--- a/lib/goodies/oban/v1/appsignal_telemetry_logger.ex
+++ b/lib/goodies/oban/v1/appsignal_telemetry_logger.ex
@@ -1,64 +1,66 @@
-defmodule Goodies.Oban.V1.AppsignalTelemetryLogger do
-  @moduledoc """
-  This module logs Oban v1.2 (latest v1 release) Telemetry events on Appsignal.
+if Code.ensure_loaded?(Appsignal) do
+  defmodule Goodies.Oban.V1.AppsignalTelemetryLogger do
+    @moduledoc """
+    This module logs Oban v1.2 (latest v1 release) Telemetry events on Appsignal.
 
-  To use it, declare on `MyApp.Application.start/1` of the app that is using Oban:
-  ```elixir
-    :telemetry.attach(
-      "oban-failure",
-      [:oban, :failure],
-      &Goodies.Oban.V1.AppsignalTelemetryLogger.handle_event/4,
-      nil
-    )
+    To use it, declare on `MyApp.Application.start/1` of the app that is using Oban:
+    ```elixir
+      :telemetry.attach(
+        "oban-failure",
+        [:oban, :failure],
+        &Goodies.Oban.V1.AppsignalTelemetryLogger.handle_event/4,
+        nil
+      )
 
-    :telemetry.attach(
-      "oban-success",
-      [:oban, :success],
-      &Goodies.Oban.V1.AppsignalTelemetryLogger.handle_event/4,
-      nil
-    )
-  ```
-  """
-  alias Appsignal.{Error, Transaction}
+      :telemetry.attach(
+        "oban-success",
+        [:oban, :success],
+        &Goodies.Oban.V1.AppsignalTelemetryLogger.handle_event/4,
+        nil
+      )
+    ```
+    """
+    alias Appsignal.{Error, Transaction}
 
-  def handle_event([:oban, event], measurement, meta, _) when event in [:success, :failure] do
-    transaction = record_event(measurement, meta)
+    def handle_event([:oban, event], measurement, meta, _) when event in [:success, :failure] do
+      transaction = record_event(measurement, meta)
 
-    if event == :failure && meta.attempt >= meta.max_attempts do
-      {reason, message, stack} = normalize_error(meta)
-      Transaction.set_error(transaction, reason, message, stack)
+      if event == :failure && meta.attempt >= meta.max_attempts do
+        {reason, message, stack} = normalize_error(meta)
+        Transaction.set_error(transaction, reason, message, stack)
+      end
+
+      Transaction.complete(transaction)
     end
 
-    Transaction.complete(transaction)
-  end
+    defp record_event(measurement, meta) do
+      metadata = %{"id" => meta.id, "queue" => meta.queue, "attempt" => meta.attempt}
 
-  defp record_event(measurement, meta) do
-    metadata = %{"id" => meta.id, "queue" => meta.queue, "attempt" => meta.attempt}
+      transaction = Transaction.start(Transaction.generate_id(), :background_job)
 
-    transaction = Transaction.start(Transaction.generate_id(), :background_job)
+      transaction
+      |> Transaction.set_action("#{meta.worker}#perform")
+      |> Transaction.set_meta_data(metadata)
+      |> Transaction.set_sample_data("params", meta.args)
+      |> Transaction.record_event("worker.perform", "", "", measurement.duration, 0)
+      |> Transaction.finish()
 
-    transaction
-    |> Transaction.set_action("#{meta.worker}#perform")
-    |> Transaction.set_meta_data(metadata)
-    |> Transaction.set_sample_data("params", meta.args)
-    |> Transaction.record_event("worker.perform", "", "", measurement.duration, 0)
-    |> Transaction.finish()
+      transaction
+    end
 
-    transaction
-  end
+    defp normalize_error(error_metadata)
 
-  defp normalize_error(error_metadata)
+    defp normalize_error(%{kind: :error, error: error, stack: stack, worker: worker}) do
+      {"#{worker}Error", stringify(error), stack}
+    end
 
-  defp normalize_error(%{kind: :error, error: error, stack: stack, worker: worker}) do
-    {"#{worker}Error", stringify(error), stack}
-  end
+    defp normalize_error(%{kind: :exception, error: error, stack: stack}) do
+      {reason, message} = Error.metadata(error)
+      {stringify(reason), stringify(message), stack}
+    end
 
-  defp normalize_error(%{kind: :exception, error: error, stack: stack}) do
-    {reason, message} = Error.metadata(error)
-    {stringify(reason), stringify(message), stack}
-  end
-
-  defp stringify(value) do
-    if is_binary(value), do: value, else: inspect(value, limit: :infinity)
+    defp stringify(value) do
+      if is_binary(value), do: value, else: inspect(value, limit: :infinity)
+    end
   end
 end

--- a/lib/goodies/oban/v2/appsignal_telemetry_logger.ex
+++ b/lib/goodies/oban/v2/appsignal_telemetry_logger.ex
@@ -1,59 +1,61 @@
-defmodule Goodies.Oban.V2.AppsignalTelemetryLogger do
-  @moduledoc """
-  This module logs Oban v2 Telemetry events on Appsignal.
+if Code.ensure_loaded?(Appsignal) do
+  defmodule Goodies.Oban.V2.AppsignalTelemetryLogger do
+    @moduledoc """
+    This module logs Oban v2 Telemetry events on Appsignal.
 
-  To use it, declare on `MyApp.Application.start/1` of the app that is using Oban:
-  ```elixir
-    :telemetry.attach(
-      "oban-job-stop",
-      [:oban, :job, :stop],
-      &Goodies.Oban.V2.AppsignalTelemetryLogger.handle_event/4,
-      nil
-    )
+    To use it, declare on `MyApp.Application.start/1` of the app that is using Oban:
+    ```elixir
+      :telemetry.attach(
+        "oban-job-stop",
+        [:oban, :job, :stop],
+        &Goodies.Oban.V2.AppsignalTelemetryLogger.handle_event/4,
+        nil
+      )
 
-    :telemetry.attach(
-      "oban-job-exception",
-      [:oban, :job, :exception],
-      &Goodies.Oban.V2.AppsignalTelemetryLogger.handle_event/4,
-      nil
-    )
-  ```
-  """
-  alias Appsignal.{Error, Transaction}
+      :telemetry.attach(
+        "oban-job-exception",
+        [:oban, :job, :exception],
+        &Goodies.Oban.V2.AppsignalTelemetryLogger.handle_event/4,
+        nil
+      )
+    ```
+    """
+    alias Appsignal.{Error, Transaction}
 
-  def handle_event([:oban, :job, event], measurement, meta, _)
-      when event in [:stop, :exception] do
-    transaction = record_event(measurement, meta)
+    def handle_event([:oban, :job, event], measurement, meta, _)
+        when event in [:stop, :exception] do
+      transaction = record_event(measurement, meta)
 
-    if event == :exception && meta.attempt >= meta.max_attempts && meta.kind != :exit do
-      {reason, message, stack} = normalize_error(meta)
-      Transaction.set_error(transaction, reason, message, stack)
+      if event == :exception && meta.attempt >= meta.max_attempts && meta.kind != :exit do
+        {reason, message, stack} = normalize_error(meta)
+        Transaction.set_error(transaction, reason, message, stack)
+      end
+
+      Transaction.complete(transaction)
     end
 
-    Transaction.complete(transaction)
-  end
+    defp record_event(measurement, meta) do
+      metadata = %{"id" => meta.id, "queue" => meta.queue, "attempt" => meta.attempt}
 
-  defp record_event(measurement, meta) do
-    metadata = %{"id" => meta.id, "queue" => meta.queue, "attempt" => meta.attempt}
+      transaction = Transaction.start(Transaction.generate_id(), :background_job)
 
-    transaction = Transaction.start(Transaction.generate_id(), :background_job)
+      transaction
+      |> Transaction.set_action("#{meta.worker}#perform")
+      |> Transaction.set_meta_data(metadata)
+      |> Transaction.set_sample_data("params", meta.args)
+      |> Transaction.record_event("worker.perform", "", "", measurement.duration, 0)
+      |> Transaction.finish()
 
-    transaction
-    |> Transaction.set_action("#{meta.worker}#perform")
-    |> Transaction.set_meta_data(metadata)
-    |> Transaction.set_sample_data("params", meta.args)
-    |> Transaction.record_event("worker.perform", "", "", measurement.duration, 0)
-    |> Transaction.finish()
+      transaction
+    end
 
-    transaction
-  end
+    defp normalize_error(%{error: error, stacktrace: stack}) do
+      {reason, message} = Error.metadata(error)
+      {stringify(reason), stringify(message), stack}
+    end
 
-  defp normalize_error(%{error: error, stacktrace: stack}) do
-    {reason, message} = Error.metadata(error)
-    {stringify(reason), stringify(message), stack}
-  end
-
-  defp stringify(value) do
-    if is_binary(value), do: value, else: inspect(value, limit: :infinity)
+    defp stringify(value) do
+      if is_binary(value), do: value, else: inspect(value, limit: :infinity)
+    end
   end
 end

--- a/lib/goodies/tesla/middleware/request_id_forwarder.ex
+++ b/lib/goodies/tesla/middleware/request_id_forwarder.ex
@@ -1,24 +1,26 @@
-defmodule Goodies.Tesla.Middleware.RequestIdForwarder do
-  @moduledoc """
-  Tesla middleware to forward *x-request-id* header to others services.
+if Code.ensure_loaded?(Tesla) do
+  defmodule Goodies.Tesla.Middleware.RequestIdForwarder do
+    @moduledoc """
+    Tesla middleware to forward *x-request-id* header to others services.
 
-  Assigns `Logger.metadata()[:request_id]` to *x-request-id* header.
-  """
+    Assigns `Logger.metadata()[:request_id]` to *x-request-id* header.
+    """
 
-  @behaviour Tesla.Middleware
+    @behaviour Tesla.Middleware
 
-  require Logger
+    require Logger
 
-  @impl Tesla.Middleware
-  def call(%Tesla.Env{} = env, next, _opts) do
-    request_id = Logger.metadata()[:request_id]
+    @impl Tesla.Middleware
+    def call(%Tesla.Env{} = env, next, _opts) do
+      request_id = Logger.metadata()[:request_id]
 
-    if is_binary(request_id) do
-      env
-      |> Tesla.put_header("x-request-id", request_id)
-      |> Tesla.run(next)
-    else
-      Tesla.run(env, next)
+      if is_binary(request_id) do
+        env
+        |> Tesla.put_header("x-request-id", request_id)
+        |> Tesla.run(next)
+      else
+        Tesla.run(env, next)
+      end
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -10,8 +10,7 @@ defmodule Goodies.MixProject do
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [warnings_as_errors: true],
-      deps: deps(),
-      aliases: aliases()
+      deps: deps()
     ]
   end
 
@@ -33,6 +32,4 @@ defmodule Goodies.MixProject do
       {:mock, "~> 0.3.0", only: :test}
     ]
   end
-
-  defp aliases, do: [test: ["coveralls", "credo --strict"]]
 end


### PR DESCRIPTION
**Why is this change necessary?**

- To improve optional dependencies on this lib.

**How does it address the issue?**

- Check dependency presence before loading modules;
- Add CI config.

**What side effects does this change have?**

- N/A

**Task card (link)**

- [ETEAM-25](https://bcredi.atlassian.net/browse/ETEAM-25)